### PR TITLE
Corrected off-by-one error in xml-result-file.

### DIFF
--- a/kopeme-junit/src/main/java/de/dagere/kopeme/junit/testrunner/PerformanceMethodStatement.java
+++ b/kopeme-junit/src/main/java/de/dagere/kopeme/junit/testrunner/PerformanceMethodStatement.java
@@ -176,8 +176,8 @@ public class PerformanceMethodStatement extends KoPeMeBasicStatement {
          }
          Thread.sleep(1); // To let other threads "breath"
       }
-      LOG.debug("Executions: " + execution);
-      tr.setRealExecutions(execution);
+      LOG.debug("Executions: " + (execution - 1));
+      tr.setRealExecutions(execution - 1);
    }
 
    public void setFinished(final boolean isFinished) {


### PR DESCRIPTION
In the xml-file, which holds the results of a measurement-run, the counts of warmupExecutions and executionTimes always displayed one more than actually executed. Counts should be set in the xml-file correct now.