### PR TITLE
Add OOM Test without warmUp

### DIFF
--- a/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/TestJUnit5ThrowingOOM.java
+++ b/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/TestJUnit5ThrowingOOM.java
@@ -1,11 +1,11 @@
 package de.dagere.kopeme.junit5;
 
 import de.dagere.kopeme.junit5.exampletests.ExampleExtension5MockitoTestThrowingOOM;
+import de.dagere.kopeme.junit5.exampletests.ExampleExtension5TestWithoutWarmUpThrowingOOM;
 import de.dagere.kopeme.junit5.exampletests.ExampleExtensionTestThrowingOOM;
 import de.dagere.kopeme.junit5.extension.KoPeMeExtension;
 
 import org.junit.Assert;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -22,6 +22,13 @@ public class TestJUnit5ThrowingOOM {
    @Test
    public void testMockitoCorrectThrowingOOM() {
       File file = JUnit5RunUtil.runJUnit5Test(ExampleExtension5MockitoTestThrowingOOM.class);
+
+      Assert.assertTrue(KoPeMeExtension.isLastRunFailed());
+   }
+
+   @Test
+   public void testWithoutWarmUpCorrectThrowingOOM() {
+      File file = JUnit5RunUtil.runJUnit5Test(ExampleExtension5TestWithoutWarmUpThrowingOOM.class);
 
       Assert.assertTrue(KoPeMeExtension.isLastRunFailed());
    }

--- a/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/exampletests/ExampleExtension5TestWithoutWarmUpThrowingOOM.java
+++ b/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/exampletests/ExampleExtension5TestWithoutWarmUpThrowingOOM.java
@@ -1,0 +1,17 @@
+package de.dagere.kopeme.junit5.exampletests;
+
+import de.dagere.kopeme.annotations.PerformanceTest;
+import de.dagere.kopeme.junit5.extension.KoPeMeExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(KoPeMeExtension.class)
+public class ExampleExtension5TestWithoutWarmUpThrowingOOM {
+
+   @Test
+   @PerformanceTest(warmup = 0, iterations = 3, repetitions = 1, timeout = 5000000, dataCollectors = "ONLYTIME", useKieker = false)
+   public void testWithoutWarmup() {
+      System.out.println("Normal Execution");
+      String[] array = new String[100000 * 100000];
+   }
+}


### PR DESCRIPTION
If the test has no warmUp, the json file is created with datacollectorResults Info.
Despite the OOM error, parameters error and failure are false.
