### PR TITLE
Add configuration file to read env variables/properties for Android projects

### DIFF
--- a/kopeme-core/src/main/java/de/dagere/kopeme/AndroidConfiguration.java
+++ b/kopeme-core/src/main/java/de/dagere/kopeme/AndroidConfiguration.java
@@ -1,0 +1,25 @@
+package de.dagere.kopeme;
+import java.io.InputStream;
+import de.dagere.kopeme.junit.rule.annotations.KoPeMeConstants;
+
+/**
+ * Configuration class for Android projects to read environment variables, properties, etc
+ * from a config.json file in src/main/resources.
+ */
+public class AndroidConfiguration {
+    
+    //  Configuration file name for Android projects inside main/src/resources folder.
+    static final String ANDROID_CONFIG = "kopeme_config.json";
+
+    public static String read(String fieldName) {
+        InputStream inputStream = AndroidConfiguration.class.getClassLoader().getResourceAsStream(ANDROID_CONFIG);
+        String fieldValue;
+        try {
+            fieldValue = KoPeMeConstants.OBJECTMAPPER.readTree(inputStream).get(fieldName).asText();
+        } catch (Exception e) {
+            System.err.println("Couldn't read Android configuration: "+e.getMessage());
+            fieldValue = null;
+        }
+        return fieldValue;
+    }
+}

--- a/kopeme-core/src/main/java/de/dagere/kopeme/KoPeMeConfiguration.java
+++ b/kopeme-core/src/main/java/de/dagere/kopeme/KoPeMeConfiguration.java
@@ -66,7 +66,11 @@ public class KoPeMeConfiguration {
    }
 
    private String getWorkingDirAsString() {
-      return System.getProperty(KOPEME_WORKINGDIR_PROPNAME, new File(".").getAbsolutePath());
+      if (AndroidConfiguration.read(KOPEME_WORKINGDIR_PROPNAME) != null) {
+         return AndroidConfiguration.read(KOPEME_WORKINGDIR_PROPNAME);
+      } else {
+         return System.getProperty(KOPEME_WORKINGDIR_PROPNAME, new File(".").getAbsolutePath());
+      }
    }
 
    private int getIntSystemProperty(final String propName, final int defaultValue) {

--- a/kopeme-core/src/main/java/de/dagere/kopeme/datastorage/FolderProvider.java
+++ b/kopeme-core/src/main/java/de/dagere/kopeme/datastorage/FolderProvider.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 import java.util.TreeMap;
+import de.dagere.kopeme.AndroidConfiguration;
 
 import de.dagere.kopeme.KoPeMeConfiguration;
 
@@ -12,6 +13,7 @@ public class FolderProvider {
    static final Long MEASURE_TIME = Long.valueOf(System.currentTimeMillis());
 
    static final String KOPEME_DEFAULT_FOLDER = System.getenv("KOPEME_HOME") != null ? System.getenv("KOPEME_HOME")
+         : AndroidConfiguration.read("KOPEME_HOME") != null ? AndroidConfiguration.read("KOPEME_HOME")
          : System.getenv("HOME") + File.separator + ".KoPeMe" + File.separator;
 
    private static FolderProvider INSTANCE;


### PR DESCRIPTION
Adding an environment variable or property to the process where adb will be executed will not work.
An application inside the emulator can't access system environment variables with `System.getenv("KOPEME_HOME")` or properties with  `System.getProperty(KOPEME_WORKINGDIR_PROPNAME);`

A solution is to read a configuration (`kopeme_config.json`) file inside Android's resources directory `<module name>/src/main/resources` with the values that are needed to be passed to KoPeMe (`"KOPEME_HOME"` and `"kopeme.workingdir"`).
The application has access to this resources folder and can read the environment variables, properties, etc from this created configuration file.

This pull request solves a part of this issue https://github.com/jenkinsci/peass-ci-plugin/issues/169.