### PR TITLE
Wait some time before flush currentWriter

### DIFF
--- a/kopeme-core/src/main/java/de/dagere/kopeme/kieker/writer/onecall/OneCallWriter.java
+++ b/kopeme-core/src/main/java/de/dagere/kopeme/kieker/writer/onecall/OneCallWriter.java
@@ -105,9 +105,13 @@ public class OneCallWriter extends AbstractMonitoringWriter implements Changeabl
    @Override
    public void onTerminating() {
       try {
+         /*
+          * Sometimes it was tried to terminate a writer which was not started yet
+          */
+         Thread.sleep(5);
          currentWriter.flush();
          currentWriter.close();
-      } catch (IOException e) {
+      } catch (IOException | InterruptedException e) {
          e.printStackTrace();
       }
    }


### PR DESCRIPTION
In some cases OneCallWriter.onTerminating() tried to flush a currentWriter which was not started yet, so NPE occured. Using Thread.sleep(5) because with if (currentWriter != null) records would possibly be lost.