### PR TITLE
Unified testDataSaving, catch Superclass AssertionError

### DIFF
--- a/kopeme-junit4/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeRuleStatement4.java
+++ b/kopeme-junit4/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeRuleStatement4.java
@@ -23,16 +23,15 @@ import junit.framework.AssertionFailedError;
 
 /**
  * Represents an execution of all runs of one test
- * 
+ *
  * TODO: Overthink weather directly configure test runs in KoPeMeRule would be more nice
- * 
+ *
  * @author dagere
- * 
  */
 public class KoPeMeRuleStatement4 extends KoPeMeBasicStatement4 {
 
    private static final Logger LOG = LogManager.getLogger(KoPeMeRuleStatement4.class);
-   
+
    private final TestResult finalResult;
    private final LinkedHashMap<String, String> params;
 
@@ -43,7 +42,7 @@ public class KoPeMeRuleStatement4 extends KoPeMeBasicStatement4 {
             (params != null) ? method.getName() + "(" + ParamNameHelper.paramsToString(params) + ")" : method.getName());
       finalResult = new TestResult(method.getName(), annotation.warmup(), datacollectors, false, params);
       this.params = params;
-      
+
       if (!ParameterChecker.parameterIndexInvalid(annotation, params)) {
          String methodFileName = (params != null) ? method.getName() + "(" + ParamNameHelper.paramsToString(params) + ")" : method.getName();
          initializeKieker(clazzname, methodFileName);
@@ -58,7 +57,7 @@ public class KoPeMeRuleStatement4 extends KoPeMeBasicStatement4 {
       if (parameterIndexInvalid) {
          return;
       }
-      
+
       final Finishable finishable = new Finishable() {
          @Override
          public void run() {

--- a/kopeme-junit4/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeRuleStatement4.java
+++ b/kopeme-junit4/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeRuleStatement4.java
@@ -100,10 +100,10 @@ public class KoPeMeRuleStatement4 extends KoPeMeBasicStatement4 {
          if (!isFinished) {
             runMainExecution(finalResult, "iteration ", annotation.iterations(), annotation.repetitions());
          }
-      } catch (final AssertionFailedError t) {
-         finalResult.finalizeCollection(t);
+      } catch (final AssertionError ae) {
+         finalResult.finalizeCollection(ae);
          saveData(SaveableTestData.createAssertFailedTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
-         throw t;
+         throw ae;
       } catch (final Throwable t) {
          t.printStackTrace();
          finalResult.finalizeCollection(t);

--- a/kopeme-junit5/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeExtensionStatement.java
+++ b/kopeme-junit5/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeExtensionStatement.java
@@ -102,10 +102,10 @@ public class KoPeMeExtensionStatement extends KoPeMeBasicStatement5 {
          if (!isFinished) {
             runMainExecution(finalResult, "iteration ", annotation.iterations(), annotation.repetitions());
          }
-      } catch (final AssertionFailedError t) {
-         finalResult.finalizeCollection(t);
+      } catch (final AssertionError ae) {
+         finalResult.finalizeCollection(ae);
          saveData(SaveableTestData.createAssertFailedTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
-         throw t;
+         throw ae;
       } catch (final Throwable t) {
          t.printStackTrace();
          finalResult.finalizeCollection(t);

--- a/kopeme-junit5/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeExtensionStatement.java
+++ b/kopeme-junit5/src/main/java/de/dagere/kopeme/junit/rule/KoPeMeExtensionStatement.java
@@ -17,16 +17,15 @@ import de.dagere.kopeme.datastorage.ParamNameHelper;
 import de.dagere.kopeme.datastorage.RunConfiguration;
 import de.dagere.kopeme.datastorage.SaveableTestData;
 import de.dagere.kopeme.junit.rule.annotations.ParameterChecker;
-import de.dagere.kopeme.runnables.PreparableTestRunnables;
 import de.dagere.kopeme.runnables.TestRunnable;
+import junit.framework.AssertionFailedError;
 
 /**
  * Represents an execution of all runs of one test
- * 
+ *
  * TODO: Overthink weather directly configure test runs in KoPeMeRule would be more nice
- * 
+ *
  * @author dagere
- * 
  */
 public class KoPeMeExtensionStatement extends KoPeMeBasicStatement5 {
 
@@ -103,18 +102,18 @@ public class KoPeMeExtensionStatement extends KoPeMeBasicStatement5 {
          if (!isFinished) {
             runMainExecution(finalResult, "iteration ", annotation.iterations(), annotation.repetitions());
          }
+      } catch (final AssertionFailedError t) {
+         finalResult.finalizeCollection(t);
+         saveData(SaveableTestData.createAssertFailedTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
+         throw t;
       } catch (final Throwable t) {
          t.printStackTrace();
          finalResult.finalizeCollection(t);
          saveData(SaveableTestData.createErrorTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
          throw t;
       }
-      if (runnables.getThrowable() != null) {
-         saveData(SaveableTestData.createErrorTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
-      } else {
-         finalResult.finalizeCollection();
-         saveData(SaveableTestData.createFineTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
-      }
+      finalResult.finalizeCollection();
+      saveData(SaveableTestData.createFineTestData(finalResult.getMethodName(), clazzname, finalResult, configuration));
    }
 
    private void runWarmup() throws Throwable {

--- a/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/TestJUnit5Throwing.java
+++ b/kopeme-junit5/src/test/java/de/dagere/kopeme/junit5/TestJUnit5Throwing.java
@@ -30,6 +30,6 @@ class TestJUnit5Throwing {
       Assertions.assertTrue(KoPeMeExtension.isLastRunFailed());
 
       Kopemedata data = JSONDataLoader.loadData(file);
-      Assertions.assertTrue(data.getMethods().isEmpty());
+      Assertions.assertTrue(data.getMethods().get(0).getDatacollectorResults().get(0).getResults().get(0).isFailure());
    }
 }


### PR DESCRIPTION
- if AssertionError was thrown, this was not recognized because it was checked for subclass AssertionFailedError
- fixed createAssertFailedTestData on AssertionError in KoPeMeBasicStatement5
- fixed TestJUnit5Throwing